### PR TITLE
feat(debug): allow a scoped tree to be passed to debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,8 @@ that library with this one somehow.
 
 ## Other Solutions
 
-* [`react-native-testing-library`](https://github.com/callstack/react-native-testing-library)
-* [`enzyme`](https://airbnb.io/enzyme/docs/guides/react-native.html)
+- [`react-native-testing-library`](https://github.com/callstack/react-native-testing-library)
+- [`enzyme`](https://airbnb.io/enzyme/docs/guides/react-native.html)
 
 ## Guiding Principles
 

--- a/src/__tests__/pretty-print.js
+++ b/src/__tests__/pretty-print.js
@@ -18,12 +18,12 @@ test('it prints correctly with one child', () => {
   );
 
   expect(prettyPrint(baseElement)).toMatchInlineSnapshot(`
-  "[36m<View>[39m
-    [36m<Text>[39m
-      [0mHello World![0m
-    [36m</Text>[39m
-  [36m</View>[39m"
-  `);
+"[36m<View>[39m
+  [36m<Text>[39m
+    [0mHello World![0m
+  [36m</Text>[39m
+[36m</View>[39m"
+`);
 });
 
 test('it prints correctly with multiple children', () => {
@@ -35,15 +35,15 @@ test('it prints correctly with multiple children', () => {
   );
 
   expect(prettyPrint(baseElement)).toMatchInlineSnapshot(`
-  "[36m<View>[39m
-    [36m<Text>[39m
-      [0mHello[0m
-    [36m</Text>[39m
-    [36m<Text>[39m
-      [0mWorld![0m
-    [36m</Text>[39m
-  [36m</View>[39m"
-  `);
+"[36m<View>[39m
+  [36m<Text>[39m
+    [0mHello[0m
+  [36m</Text>[39m
+  [36m<Text>[39m
+    [0mWorld![0m
+  [36m</Text>[39m
+[36m</View>[39m"
+`);
 });
 
 test('it supports truncating the output length', () => {

--- a/src/__tests__/pretty-print.js
+++ b/src/__tests__/pretty-print.js
@@ -1,19 +1,57 @@
 import React from 'react';
-import { Text } from 'react-native';
+import { Text, View } from 'react-native';
 
 import { render } from '../';
 import { prettyPrint } from '../pretty-print';
 
-test('it prints out the given element tree', () => {
-  const { container } = render(<Text>Hello World!</Text>);
-  expect(prettyPrint(container)).toMatchInlineSnapshot(`
-"[36m<Text>[39m
-  [0mHello World![0m
-[36m</Text>[39m"
-`);
+test('it prints correctly with no children', () => {
+  const { baseElement } = render(<View />);
+
+  expect(prettyPrint(baseElement)).toMatchInlineSnapshot(`"[36m<View />[39m"`);
+});
+
+test('it prints correctly with one child', () => {
+  const { baseElement } = render(
+    <View>
+      <Text>Hello World!</Text>
+    </View>,
+  );
+
+  expect(prettyPrint(baseElement)).toMatchInlineSnapshot(`
+  "[36m<View>[39m
+    [36m<Text>[39m
+      [0mHello World![0m
+    [36m</Text>[39m
+  [36m</View>[39m"
+  `);
+});
+
+test('it prints correctly with multiple children', () => {
+  const { baseElement } = render(
+    <View>
+      <Text>Hello</Text>
+      <Text>World!</Text>
+    </View>,
+  );
+
+  expect(prettyPrint(baseElement)).toMatchInlineSnapshot(`
+  "[36m<View>[39m
+    [36m<Text>[39m
+      [0mHello[0m
+    [36m</Text>[39m
+    [36m<Text>[39m
+      [0mWorld![0m
+    [36m</Text>[39m
+  [36m</View>[39m"
+  `);
 });
 
 test('it supports truncating the output length', () => {
-  const { container } = render(<Text>Hello World!</Text>);
-  expect(prettyPrint(container, 5)).toMatch(/\.\.\./);
+  const { baseElement } = render(
+    <View>
+      <Text>Hello World!</Text>
+    </View>,
+  );
+
+  expect(prettyPrint(baseElement, 5)).toMatch(/\.\.\./);
 });

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -295,7 +295,7 @@ export declare function render<T>(ui: ReactElement, options: RenderOptionsWithQu
 export interface RenderResult {
   container: ReactTestRenderer
   baseElement: NativeTestInstance
-  debug: () => void
+  debug: (el?: NativeTestInstance) => void
   rerender: (ui: ReactElement) => void
   unmount: () => void
 }

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ function render(ui, { options = {}, wrapper: WrapperComponent } = {}) {
   return {
     container,
     baseElement,
-    debug: (el = container) => console.log(prettyPrint(el)),
+    debug: (el = baseElement) => console.log(prettyPrint(el)),
     unmount: () => container.unmount(),
     rerender: rerenderUi => {
       act(() => {

--- a/src/pretty-print.js
+++ b/src/pretty-print.js
@@ -1,8 +1,42 @@
 import prettyFormat from 'pretty-format';
+import React from 'react';
 const { ReactTestComponent, ReactElement } = prettyFormat.plugins;
 
-function getPrettyOutput(reactElement, maxLength, options) {
-  const debugContent = prettyFormat(reactElement, {
+function toJSON(node) {
+  if (typeof node === 'string') {
+    return node;
+  }
+
+  const { children, ...props } = node.props;
+  let renderedChildren = null;
+
+  if (children) {
+    React.Children.forEach(children, child => {
+      const renderedChild = toJSON(child);
+
+      if (renderedChildren === null) {
+        renderedChildren = [renderedChild];
+      } else {
+        renderedChildren.push(renderedChild);
+      }
+    });
+  }
+
+  const json = {
+    type: node.type.displayName || node.type,
+    props: props,
+    children: renderedChildren,
+  };
+
+  Object.defineProperty(json, '$$typeof', {
+    value: Symbol.for('react.test.json'),
+  });
+
+  return json;
+}
+
+function prettyPrint(reactElement, maxLength, options) {
+  const debugContent = prettyFormat(toJSON(reactElement), {
     plugins: [ReactTestComponent, ReactElement],
     printFunctionName: false,
     highlight: true,
@@ -12,14 +46,6 @@ function getPrettyOutput(reactElement, maxLength, options) {
   return maxLength !== undefined && debugContent && debugContent.toString().length > maxLength
     ? `${debugContent.slice(0, maxLength)}...`
     : debugContent;
-}
-
-function prettyPrint(reactElement, ...args) {
-  try {
-    return getPrettyOutput(reactElement.toJSON(), ...args);
-  } catch (e) {
-    return getPrettyOutput(reactElement, ...args);
-  }
 }
 
 export { prettyPrint };


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Added the ability to pass an element to `debug()`

<!-- Why are these changes necessary? -->

**Why**:

This is how it is in `react-testing-library`. I've always intended it to be this way, I just never got around to implementing a custom `toJSON` that would allow it. Since this changes the behavior of debug and potentially breaks snapshots, this will also go in 2.0

<!-- How were these changes implemented? -->

**How**:

This required a modification of the `toJSON` from react-test-renderer. This takes a test renderer instance and makes it a simplified JSON object that can be pretty printed.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the [docs site](https://github.com/bcarroll22/native-testing-library-docs)
- [x] Typescript definitions updated
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->