### PR TITLE
Fix #15 make render return bound queries passed as options

### DIFF
--- a/src/__tests__/render.js
+++ b/src/__tests__/render.js
@@ -30,3 +30,13 @@ test('renders options.wrapper around node', () => {
 </View>
 `);
 });
+
+test('returns the queries passed as options bound to the container', () => {
+  const _getQueryPassedAsOption = { bind: jest.fn(() => _getQueryPassedAsOption) }
+  const queries = { getQueryPassedAsOption: _getQueryPassedAsOption };
+
+  const { container, getQueryPassedAsOption } = render(<View />, { queries });
+
+  expect(queries.getQueryPassedAsOption.bind).toHaveBeenCalledWith(null,container);
+  expect(getQueryPassedAsOption).toEqual(_getQueryPassedAsOption);
+});

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ import { resultContainer, TestHook } from './hooks';
 import { getQueriesForElement } from './get-queries-for-element';
 import { fireEvent as rntlFireEvent, NativeEvent } from './events';
 
-function render(ui, { options = {}, wrapper: WrapperComponent } = {}) {
+function render(ui, { options = {}, wrapper: WrapperComponent, queries } = {}) {
   const wrapUiIfNeeded = innerElement =>
     WrapperComponent ? <WrapperComponent>{innerElement}</WrapperComponent> : innerElement;
 
@@ -31,7 +31,7 @@ function render(ui, { options = {}, wrapper: WrapperComponent } = {}) {
         container.update(wrapUiIfNeeded(rerenderUi));
       });
     },
-    ...getQueriesForElement(container),
+    ...getQueriesForElement(container, queries || undefined),
   };
 }
 


### PR DESCRIPTION

**What**:

Fix #15 make render return bound queries passed as options

**Why**:

The [documentation](https://www.native-testing-library.com/docs/api-render#queries) mentions that queries can be passed as an option to render to specify which queries to bind, or add custom bound queries. This commit fixes this behavior and adds a regression test.

**How**:

In the implementation of the `render` function it passes the received `queries` from options to `getQueriesForElement`.

**Checklist**:

- [ ] Documentation added to the
      [docs site](https://github.com/bcarroll22/native-testing-library-docs) N/A
- [ ] Typescript definitions updated N/A
- [x] Tests
- [x] Ready to be merged <!-- In your opinion -->

<!-- feel free to add additional comments -->