### PR TITLE
Fix TypeScript return types for query methods

### DIFF
--- a/typings/queries.d.ts
+++ b/typings/queries.d.ts
@@ -2,70 +2,70 @@ import { ReactTestRenderer } from 'react-test-renderer';
 
 import { Matcher, MatcherOptions } from './matches';
 import { WaitForElementOptions } from './wait-for-element';
-import { SelectorMatcherOptions } from './query-helpers';
+import { NativeTestInstance, SelectorMatcherOptions } from './query-helpers';
 
 export type QueryByBoundProp = (
   testRenderer: ReactTestRenderer,
   id: Matcher,
   options?: MatcherOptions,
-) => ReactTestRenderer | null;
+) => NativeTestInstance | null;
 
 export type AllByBoundProp = (
   testRenderer: ReactTestRenderer,
   id: Matcher,
   options?: MatcherOptions,
-) => ReactTestRenderer[];
+) => NativeTestInstance[];
 
 export type FindAllByBoundProp = (
   testRenderer: ReactTestRenderer,
   id: Matcher,
   options?: MatcherOptions,
-) => Promise<ReactTestRenderer[]>;
+) => Promise<NativeTestInstance[]>;
 
 export type GetByBoundProp = (
   testRenderer: ReactTestRenderer,
   id: Matcher,
   options?: MatcherOptions,
-) => ReactTestRenderer;
+) => NativeTestInstance;
 
 export type FindByBoundProp = (
   testRenderer: ReactTestRenderer,
   id: Matcher,
   options?: MatcherOptions,
   waitForElementOptions?: WaitForElementOptions,
-) => Promise<ReactTestRenderer>;
+) => Promise<NativeTestInstance>;
 
 export type QueryByText = (
   testRenderer: ReactTestRenderer,
   id: Matcher,
   options?: SelectorMatcherOptions,
-) => ReactTestRenderer | null;
+) => NativeTestInstance | null;
 
 export type AllByText = (
   testRenderer: ReactTestRenderer,
   id: Matcher,
   options?: SelectorMatcherOptions,
-) => ReactTestRenderer[];
+) => NativeTestInstance[];
 
 export type FindAllByText = (
   testRenderer: ReactTestRenderer,
   id: Matcher,
   options?: MatcherOptions,
   waitForElementOptions?: WaitForElementOptions,
-) => Promise<ReactTestRenderer[]>;
+) => Promise<NativeTestInstance[]>;
 
 export type GetByText = (
   testRenderer: ReactTestRenderer,
   id: Matcher,
   options?: WaitForElementOptions,
-) => ReactTestRenderer;
+) => NativeTestInstance;
 
 export type FindByText = (
   testRenderer: ReactTestRenderer,
   id: Matcher,
   options?: MatcherOptions,
   waitForElementOptions?: WaitForElementOptions,
-) => Promise<ReactTestRenderer>;
+) => Promise<NativeTestInstance>;
 
 export const getByHintText: GetByBoundProp;
 export const getByLabelText: GetByBoundProp;


### PR DESCRIPTION
<!--

Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!

-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
Modified return types for all query methods (e.g. getByTestId) from `ReactTestRenderer` to `NativeTestInstance`.

**Why**:

<!-- Why are these changes necessary? -->
As noted in https://github.com/testing-library/native-testing-library/issues/20, for projects using TypeScript, it is confusing to see false type errors within tests when firing events and accessing element props.

**How**:

<!-- How were these changes implemented? -->
Simply modified the type definitions directly. I'm assuming this project is written with normal JavaScript and therefore TypeScript definitions are manually maintained?

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/bcarroll22/native-testing-library-docs) (N/A)
- [x] Typescript definitions updated
- [ ] Tests (N/A)
- [x] Ready to be merged <!-- In your opinion -->

<!-- feel free to add additional comments -->
