### PR TITLE
Rename asFragment -> asJSON

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -29,7 +29,7 @@ export type RenderResult<Q extends Queries = typeof queries> = {
   debug: (element?: NativeTestInstance) => void;
   rerender: (ui: ReactElement) => void;
   unmount: () => void;
-  asFragment: () => NativeTestInstanceJSON;
+  asJSON: () => NativeTestInstanceJSON;
 } & { [P in keyof Q]: BoundFunction<Q[P]> };
 
 export interface RenderOptions<Q extends Queries = typeof queries> {


### PR DESCRIPTION
The library exports `asJSON`; `asFragment` is a DOM function.

**What**:

Fix name of method in return of `render`.

**Why**:

The library returns `asJSON` while the typings have it returning `asFragment`.

**How**:

Updated the typings.

**Checklist**:

- [ ] Documentation added to the
      [docs site](https://github.com/bcarroll22/native-testing-library-docs) (N/A)
- [X] Typescript definitions updated
- [ ] Tests (N/A
- [X] Ready to be merged <!-- In your opinion -->