### PR TITLE
fix(act): improve async act detection

### DIFF
--- a/cleanup-after-each.js
+++ b/cleanup-after-each.js
@@ -1,1 +1,3 @@
-afterEach(require('./dist').cleanup);
+afterEach(() => {
+  return require('./dist/cleanup-async')();
+});

--- a/src/__tests__/new-act.js
+++ b/src/__tests__/new-act.js
@@ -1,23 +1,19 @@
-let act, asyncAct;
+let asyncAct;
+
+jest.mock('react-test-renderer', () => ({
+  act: cb => {
+    return cb();
+  },
+}));
 
 beforeEach(() => {
   jest.resetModules();
-  act = require('..').act;
   asyncAct = require('../act-compat').asyncAct;
   jest.spyOn(console, 'error').mockImplementation(() => {});
 });
 
 afterEach(() => {
   console.error.mockRestore();
-});
-
-jest.mock('react-test-renderer', () => ({}));
-
-test('act works even when there is no act from test renderer', () => {
-  const callback = jest.fn();
-  act(callback);
-  expect(callback).toHaveBeenCalledTimes(1);
-  expect(console.error).toHaveBeenCalledTimes(0);
 });
 
 test('async act works when it does not exist (older versions of react)', async () => {

--- a/src/cleanup-async.js
+++ b/src/cleanup-async.js
@@ -1,0 +1,10 @@
+// This file is for use by the top-level export
+// @testing-library/react/cleanup-after-each
+// It is not meant to be used directly
+
+module.exports = async function cleanupAsync() {
+  const { asyncAct } = require('./act-compat');
+  const { cleanup } = require('./index');
+  await asyncAct(async () => {});
+  cleanup();
+};


### PR DESCRIPTION
**What**:

Improve async act detection to achieve parity with RTL after https://github.com/testing-library/react-testing-library/pull/407 and https://github.com/testing-library/react-testing-library/pull/427 were merged.

**Why**:

This handles async act cases and detecting async act more effectively.

**How**:

<!-- How were these changes implemented? -->

This mostly just worked pulling it over from RTL. The only differences came because of using React Test Renderer instead of ReactDOM `act`, and not rendering globally to a JSDOM document.

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the
      [docs site](https://github.com/bcarroll22/native-testing-library-docs)
- [x] Typescript definitions updated
- [x] Tests
- [x] Ready to be merged <!-- In your opinion -->

<!-- feel free to add additional comments -->
