### PR TITLE
Fix matcher when values don't match types

### DIFF
--- a/src/__tests__/misc.js
+++ b/src/__tests__/misc.js
@@ -100,3 +100,17 @@ test("it finds <TextInput /> by value={'hey'} when another a Switch with value={
 
   getByDisplayValue('hey');
 });
+
+test("it finds <Picker /> by value={'java'} when another a Switch with value={true} is present", () => {
+  const { getByDisplayValue } = render(
+    <View>
+      <Switch value={true} />
+      <Picker selectedValue={'java'} onValueChange={itemValue => setValue(itemValue)}>
+        <Picker.Item label="Java" value="java" />
+        <Picker.Item label="JavaScript" value="js" />
+      </Picker>
+    </View>,
+  );
+
+  getByDisplayValue('java');
+});

--- a/src/__tests__/misc.js
+++ b/src/__tests__/misc.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, Picker, Switch, Text, View } from 'react-native';
+import { Button, Picker, Switch, Text, View, TextInput } from 'react-native';
 import { toMatchDiffSnapshot } from 'snapshot-diff';
 
 import { cleanup, fireEvent, render } from '../';
@@ -88,4 +88,15 @@ test('it finds <Switch /> by value={false}', () => {
   const { getByDisplayValue } = render(<Switch value={false} />);
 
   getByDisplayValue(false);
+});
+
+test("it finds <TextInput /> by value={'hey'} when another a Switch with value={true} is present", () => {
+  const { getByDisplayValue } = render(
+    <View>
+      <Switch value={true} />
+      <TextInput value={'hey'} />
+    </View>,
+  );
+
+  getByDisplayValue('hey');
 });

--- a/src/lib/matches.js
+++ b/src/lib/matches.js
@@ -1,5 +1,5 @@
 function fuzzyMatches(textToMatch, node, matcher, normalizer) {
-  if (typeof matcher === 'boolean') {
+  if (typeof matcher === 'boolean' || typeof textToMatch === 'boolean') {
     return textToMatch == matcher;
   }
 
@@ -18,7 +18,7 @@ function fuzzyMatches(textToMatch, node, matcher, normalizer) {
 }
 
 function matches(textToMatch, node, matcher, normalizer) {
-  if (typeof matcher === 'boolean') {
+  if (typeof matcher === 'boolean' || typeof textToMatch === 'boolean') {
     return textToMatch === matcher;
   }
 


### PR DESCRIPTION
<!--

Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!

-->

**What**: We added the ability to query by boolean for switches (as they have a value that is on/off).  It broke a few things, mainly Switches being rendered alongside other components that get queried by displayValue (TextInput/Picker).

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**Why**: We want to be able to test components that contain switches and TextInputs/Pickers

<!-- Why are these changes necessary? -->

**How**: Don't try and normalize boolean values

<!-- How were these changes implemented? -->

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/bcarroll22/native-testing-library-docs)
- [ ] Typescript definitions updated
- [x] Tests
- [ ] Ready to be merged <!-- In your opinion -->

Not 100% sure this is the correct way to go about this, but it works and passes the test cases I added that were breaking for me in my project.
