### PR TITLE
feat: formatting options for render() to remove options from debug()

### DIFF
--- a/src/__tests__/debug.js
+++ b/src/__tests__/debug.js
@@ -11,6 +11,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  log = undefined;
   console.log.mockRestore();
 });
 
@@ -23,18 +24,21 @@ test('debug pretty prints the baseElement', () => {
 });
 
 test('debug can remove specified props from output', () => {
-  const options = {
-    removeProps: ['style', 'pointerEvents', 'collapsable'],
-  };
-
   const { debug } = render(
     <View style={{ width: 300 }}>
       <Text>Hello World!</Text>
     </View>,
-    { formatting: options },
+    {
+      options: {
+        debug: {
+          omitProps: ['style', 'pointerEvents', 'collapsable'],
+        },
+      },
+    },
   );
 
   debug();
+
   expect(console.log).toHaveBeenCalledTimes(1);
   expect(log).toMatchInlineSnapshot(`
     "[36m<View>[39m

--- a/src/__tests__/debug.js
+++ b/src/__tests__/debug.js
@@ -1,10 +1,12 @@
 import React from 'react';
-import { Text } from 'react-native';
+import { Text, View } from 'react-native';
 
 import { cleanup, render } from '../';
 
+let log;
+
 beforeEach(() => {
-  jest.spyOn(console, 'log').mockImplementation(() => {});
+  jest.spyOn(console, 'log').mockImplementation(output => (log = output));
 });
 
 afterEach(() => {
@@ -18,4 +20,31 @@ test('debug pretty prints the baseElement', () => {
   debug();
   expect(console.log).toHaveBeenCalledTimes(1);
   expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Hello World'));
+});
+
+test('debug can remove specified props from output', () => {
+  const options = {
+    propsToRemove: ['style', 'pointerEvents', 'collapsable'],
+  };
+
+  const { debug } = render(
+    <View style={{ width: 300 }}>
+      <Text>Hello World!</Text>
+    </View>,
+    { formatting: options },
+  );
+
+  debug();
+  expect(console.log).toHaveBeenCalledTimes(1);
+  expect(log).toMatchInlineSnapshot(`
+    "[36m<View>[39m
+      [36m<View>[39m
+        [36m<View>[39m
+          [36m<Text>[39m
+            [0mHello World![0m
+          [36m</Text>[39m
+        [36m</View>[39m
+      [36m</View>[39m
+    [36m</View>[39m"
+  `);
 });

--- a/src/__tests__/debug.js
+++ b/src/__tests__/debug.js
@@ -24,7 +24,7 @@ test('debug pretty prints the baseElement', () => {
 
 test('debug can remove specified props from output', () => {
   const options = {
-    propsToRemove: ['style', 'pointerEvents', 'collapsable'],
+    removeProps: ['style', 'pointerEvents', 'collapsable'],
   };
 
   const { debug } = render(

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,8 @@ import act from './act-compat';
 const renderers = new Set();
 
 function render(ui, { options = {}, wrapper: WrapperComponent, queries } = {}) {
+  const { debug, ...rest } = options;
+
   const wrapUiIfNeeded = innerElement =>
     WrapperComponent ? (
       <AppContainer>
@@ -27,7 +29,7 @@ function render(ui, { options = {}, wrapper: WrapperComponent, queries } = {}) {
   let testRenderer;
 
   act(() => {
-    testRenderer = TR.create(wrapUiIfNeeded(ui), options);
+    testRenderer = TR.create(wrapUiIfNeeded(ui), rest);
   });
 
   renderers.add(testRenderer);
@@ -39,7 +41,7 @@ function render(ui, { options = {}, wrapper: WrapperComponent, queries } = {}) {
   return {
     baseElement,
     container,
-    debug: (el = baseElement) => console.log(prettyPrint(el, undefined, { debug: options.debug })),
+    debug: (el = baseElement) => console.log(prettyPrint(el, undefined, { debug })),
     unmount: () => testRenderer.unmount(),
     rerender: rerenderUi => {
       act(() => {

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ import act from './act-compat';
 
 const renderers = new Set();
 
-function render(ui, { options = {}, wrapper: WrapperComponent, queries, formatting = {} } = {}) {
+function render(ui, { options = {}, wrapper: WrapperComponent, queries } = {}) {
   const wrapUiIfNeeded = innerElement =>
     WrapperComponent ? (
       <AppContainer>
@@ -39,7 +39,7 @@ function render(ui, { options = {}, wrapper: WrapperComponent, queries, formatti
   return {
     baseElement,
     container,
-    debug: (el = baseElement) => console.log(prettyPrint(el, undefined, { formatting })),
+    debug: (el = baseElement) => console.log(prettyPrint(el, undefined, { debug: options.debug })),
     unmount: () => testRenderer.unmount(),
     rerender: rerenderUi => {
       act(() => {

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ import act from './act-compat';
 
 const renderers = new Set();
 
-function render(ui, { options = {}, wrapper: WrapperComponent, queries } = {}) {
+function render(ui, { options = {}, wrapper: WrapperComponent, queries, formatting = {} } = {}) {
   const wrapUiIfNeeded = innerElement =>
     WrapperComponent ? (
       <AppContainer>
@@ -39,7 +39,7 @@ function render(ui, { options = {}, wrapper: WrapperComponent, queries } = {}) {
   return {
     baseElement,
     container,
-    debug: (el = baseElement) => console.log(prettyPrint(el)),
+    debug: (el = baseElement) => console.log(prettyPrint(el, undefined, { formatting })),
     unmount: () => testRenderer.unmount(),
     rerender: rerenderUi => {
       act(() => {

--- a/src/lib/__tests__/pretty-print.js
+++ b/src/lib/__tests__/pretty-print.js
@@ -96,13 +96,8 @@ test('it supports removing props from output', () => {
     </View>,
   );
 
-  const options = {
-    formatting: {
-      removeProps: ['style', 'pointerEvents'],
-    },
-  };
-
-  expect(prettyPrint(container, undefined, options)).toMatchInlineSnapshot(`
+  expect(prettyPrint(container, undefined, { debug: { omitProps: ['style', 'pointerEvents'] } }))
+    .toMatchInlineSnapshot(`
     "[36m<View[39m
       [33mcollapsable[39m=[32m{true}[39m
     [36m>[39m

--- a/src/lib/__tests__/pretty-print.js
+++ b/src/lib/__tests__/pretty-print.js
@@ -98,7 +98,7 @@ test('it supports removing props from output', () => {
 
   const options = {
     formatting: {
-      propsToRemove: ['style', 'pointerEvents'],
+      removeProps: ['style', 'pointerEvents'],
     },
   };
 

--- a/src/lib/__tests__/pretty-print.js
+++ b/src/lib/__tests__/pretty-print.js
@@ -88,3 +88,29 @@ test('it supports truncating the output length', () => {
 
   expect(prettyPrint(container, 5)).toMatch(/\.\.\./);
 });
+
+test('it supports removing props from output', () => {
+  const { container } = render(
+    <View style={{ width: 100 }}>
+      <Text>Hello World!</Text>
+    </View>,
+  );
+
+  const options = {
+    formatting: {
+      propsToRemove: ['style', 'pointerEvents'],
+    },
+  };
+
+  expect(prettyPrint(container, undefined, options)).toMatchInlineSnapshot(`
+    "[36m<View[39m
+      [33mcollapsable[39m=[32m{true}[39m
+    [36m>[39m
+      [36m<View>[39m
+        [36m<Text>[39m
+          [0mHello World![0m
+        [36m</Text>[39m
+      [36m</View>[39m
+    [36m</View>[39m"
+  `);
+});

--- a/src/lib/pretty-print.js
+++ b/src/lib/pretty-print.js
@@ -7,14 +7,9 @@ const { ReactTestComponent, ReactElement } = prettyFormat.plugins;
 
 function prettyPrint(element, maxLength, options = {}) {
   let plugins = [ReactTestComponent, ReactElement];
-  const { formatting, ...rest } = options;
+  const { debug, ...rest } = options;
 
-  if (formatting && formatting.removeProps) {
-    const formatterPlugin = createFormatter(options.formatting.removeProps);
-    plugins = [formatterPlugin, ...plugins];
-  }
-
-  const debugContent = prettyFormat(toJSON(element), {
+  const debugContent = prettyFormat(toJSON(element, debug), {
     plugins: plugins,
     printFunctionName: false,
     highlight: true,
@@ -24,25 +19,6 @@ function prettyPrint(element, maxLength, options = {}) {
   return maxLength !== undefined && debugContent && debugContent.toString().length > maxLength
     ? `${debugContent.slice(0, maxLength)}...`
     : debugContent;
-}
-
-function createFormatter(propsToRemove) {
-  const plugin = {
-    test(val) {
-      return val.props !== undefined;
-    },
-    serialize(element, config, indentation, depth, refs, printer) {
-      Object.keys(element.props).map(prop => {
-        if (propsToRemove.includes(prop)) {
-          delete element.props[prop];
-        }
-      });
-
-      return ReactTestComponent.serialize(element, config, indentation, depth, refs, printer);
-    },
-  };
-
-  return plugin;
 }
 
 export { prettyPrint };

--- a/src/lib/pretty-print.js
+++ b/src/lib/pretty-print.js
@@ -9,8 +9,8 @@ function prettyPrint(element, maxLength, options = {}) {
   let plugins = [ReactTestComponent, ReactElement];
   const { formatting, ...rest } = options;
 
-  if (formatting && formatting.propsToRemove) {
-    const formatterPlugin = createFormatter(options.formatting.propsToRemove);
+  if (formatting && formatting.removeProps) {
+    const formatterPlugin = createFormatter(options.formatting.removeProps);
     plugins = [formatterPlugin, ...plugins];
   }
 
@@ -38,11 +38,7 @@ function createFormatter(propsToRemove) {
         }
       });
 
-      if (ReactTestComponent.test(element)) {
-        return ReactTestComponent.serialize(element, config, indentation, depth, refs, printer);
-      }
-
-      return ReactElement.serialize(element, config, indentation, depth, refs, printer);
+      return ReactTestComponent.serialize(element, config, indentation, depth, refs, printer);
     },
   };
 

--- a/src/lib/to-json.js
+++ b/src/lib/to-json.js
@@ -1,12 +1,12 @@
-function toJSON({ _fiber: { stateNode = null } = {} } = {}) {
+function toJSON({ _fiber: { stateNode = null } = {} } = {}, options = {}) {
   if (!stateNode) return null;
   if (stateNode.rootContainerInstance && stateNode.rootContainerInstance.children.length === 0)
     return null;
 
-  return _toJSON(stateNode);
+  return _toJSON(stateNode, options);
 }
 
-function _toJSON(inst) {
+function _toJSON(inst, { omitProps = [] }) {
   if (inst.isHidden) {
     // Omit timed out children from output entirely. This seems like the least
     // surprising behavior. We could perhaps add a separate API that includes
@@ -23,12 +23,13 @@ function _toJSON(inst) {
       const { children, ...props } = inst.props;
 
       // Convert all children to the JSON format
-      const renderedChildren = inst.children.map(child => _toJSON(child));
+      const renderedChildren = inst.children.map(child => _toJSON(child, { omitProps }));
 
       // Function props get noisy in debug output, so we'll exclude them
+      // Also exclude any props configured via options.omitProps
       let renderedProps = {};
       Object.keys(props).filter(name => {
-        if (typeof props[name] !== 'function') {
+        if (typeof props[name] !== 'function' && !omitProps.includes(name)) {
           renderedProps[name] = props[name];
         }
       });

--- a/typings/pretty-print.d.ts
+++ b/typings/pretty-print.d.ts
@@ -3,9 +3,9 @@ import { NativeTestInstance } from './query-helpers';
 export function prettyPrint(
   element: NativeTestInstance | string,
   maxLength?: number,
-  options: {
-    formatting: {
-      removeProps: string[];
+  options?: {
+    debug: {
+      omitProps: string[];
     };
   },
 ): string | false;

--- a/typings/pretty-print.d.ts
+++ b/typings/pretty-print.d.ts
@@ -5,7 +5,7 @@ export function prettyPrint(
   maxLength?: number,
   options: {
     formatting: {
-      propsToRemove: string[];
+      removeProps: string[];
     };
   },
 ): string | false;

--- a/typings/pretty-print.d.ts
+++ b/typings/pretty-print.d.ts
@@ -3,4 +3,9 @@ import { NativeTestInstance } from './query-helpers';
 export function prettyPrint(
   element: NativeTestInstance | string,
   maxLength?: number,
+  options: {
+    formatting: {
+      propsToRemove: string[];
+    };
+  },
 ): string | false;


### PR DESCRIPTION
**What**:

Added a `formatting` option to `render()` to optionally remove noisy props from debug output

**Why**:

A lot of times I'm not concerned with style props and they can make the debug output hard to read.

**How**:

Added a config parameter to the `render()` call that will configure prettyFormat 

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/bcarroll22/native-testing-library-docs)
- [x] Typescript definitions updated
- [x] Tests
- [x] Ready to be merged <!-- In your opinion -->

<!-- feel free to add additional comments -->

I saw an earlier issue regarding something similar, and I've written an override in my custom render for projects I work on, but I thought others might want this feature as well. 
