### PR TITLE
Fix local/import type declaration conflict

### DIFF
--- a/typings/query-helpers.d.ts
+++ b/typings/query-helpers.d.ts
@@ -1,4 +1,4 @@
-import { ReactTestInstance } from 'react-test-renderer';
+import { ReactTestInstance as ReactTestInstanceBase } from 'react-test-renderer';
 
 import { Matcher, MatcherOptions } from './matches';
 
@@ -8,7 +8,7 @@ export type SelectorMatcherOptions = Omit<MatcherOptions, 'selector'> & {
   selector?: string;
 };
 
-type ReactTestInstance = {
+type ReactTestInstance = ReactTestInstanceBase & {
   getProp: (name: string) => NativeTestInstance;
   parentNode: NativeTestInstance;
 };

--- a/typings/query-helpers.d.ts
+++ b/typings/query-helpers.d.ts
@@ -1,4 +1,4 @@
-import { ReactTestInstance as ReactTestInstanceBase } from 'react-test-renderer';
+import { ReactTestInstance } from 'react-test-renderer';
 
 import { Matcher, MatcherOptions } from './matches';
 
@@ -8,13 +8,13 @@ export type SelectorMatcherOptions = Omit<MatcherOptions, 'selector'> & {
   selector?: string;
 };
 
-type ReactTestInstance = ReactTestInstanceBase & {
+type ReactTestInstanceExtended = ReactTestInstance & {
   getProp: (name: string) => NativeTestInstance;
   parentNode: NativeTestInstance;
 };
 
 export type NativeTestInstance = Omit<
-  ReactTestInstance,
+  ReactTestInstanceExtended,
   'findAllByProps' | 'findAllByType' | 'findByProps' | 'findByType' | 'instance'
 >;
 


### PR DESCRIPTION
<!--

Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!

-->

**What**:

Avoid importing a type with the same name as a local type.

**Why**:

TypeScript 3.7 introduced a breaking change which fails when you declare a local type with the same name as an imported type: https://devblogs.microsoft.com/typescript/announcing-typescript-3-7/#local-and-imported-type-declarations-now-conflict

```
node_modules/@testing-library/react-native/typings/query-helpers.d.ts:1:10 - error TS2440: Import declaration conflicts with local declaration of 'ReactTestInstance'.

1 import { ReactTestInstance } from 'react-test-renderer';
```

**How**:

Use an import alias and do proper module augmentation.

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/bcarroll22/native-testing-library-docs) (N/A)
- [X] Typescript definitions updated
- [ ] Tests (N/A)
- [X] Ready to be merged

<!-- feel free to add additional comments -->
