### PR TITLE
fix matches to account for empty strings

### DIFF
--- a/src/lib/matches.js
+++ b/src/lib/matches.js
@@ -3,7 +3,7 @@ function fuzzyMatches(textToMatch, node, matcher, normalizer) {
     return textToMatch == matcher;
   }
 
-  if (!textToMatch) {
+  if (!textToMatch && textToMatch !== '') {
     return false;
   }
 
@@ -22,7 +22,7 @@ function matches(textToMatch, node, matcher, normalizer) {
     return textToMatch === matcher;
   }
 
-  if (!textToMatch) {
+  if (!textToMatch && textToMatch !== '') {
     return false;
   }
 


### PR DESCRIPTION
**What**:

The specific issue I am trying to fix via this PR is here:

https://github.com/testing-library/native-testing-library/issues/86

Basically, the *DisplayValue queries do not work with empty strings.  This fixes the matches file so that we can match empty strings.

**Why**:

I think these changes are necessary to match empty text fields.

**How**:

I verified that this fixed my issue locally.  I ran tests after this, and they passed.

**Checklist**:

- [ ] Documentation added to the
      [docs site](https://github.com/bcarroll22/native-testing-library-docs) N/A
- [ ] Typescript definitions updated N/A
- [x] Tests (I ran them locally and they worked.  I can add additional test cases if deemed necessary.)
- [x] Ready to be merged
