### PR TITLE
Fix for console.error argument not being a string

### DIFF
--- a/src/__tests__/old-act.js
+++ b/src/__tests__/old-act.js
@@ -100,4 +100,47 @@ test('async act recovers from sync errors', async () => {
   `);
 });
 
+test('async act can handle any sort of console.error', async () => {
+  await asyncAct(async () => {
+    console.error({ error: 'some error' });
+    await null;
+  });
+
+  expect(console.error).toHaveBeenCalledTimes(2);
+  expect(console.error.mock.calls).toMatchInlineSnapshot(`
+    Array [
+      Array [
+        Array [
+          Object {
+            "error": "some error",
+          },
+        ],
+      ],
+      Array [
+        "It looks like you're using a version of react-test-renderer that supports the \\"act\\" function, but not an awaitable version of \\"act\\" which you will need. Please upgrade to at least react-test-renderer@16.9.0 to remove this warning.",
+      ],
+    ]
+  `);
+});
+
+test('async act should not show an error when ReactTestUtils.act returns something', async () => {
+  jest.resetModules();
+  jest.mock('react-test-renderer', () => ({
+    act: () => {
+      return new Promise(resolve => {
+        console.error(
+          'Warning: The callback passed to TestRenderer.act(...) function must not return anything',
+        );
+        resolve();
+      });
+    },
+  }));
+  asyncAct = require('../act-compat').asyncAct;
+  await asyncAct(async () => {
+    await null;
+  });
+
+  expect(console.error).toHaveBeenCalledTimes(0);
+});
+
 /* eslint no-console:0 */

--- a/src/act-compat.js
+++ b/src/act-compat.js
@@ -22,12 +22,15 @@ function asyncAct(cb) {
         console.error = function error(...args) {
           /* if console.error fired *with that specific message* */
           /* istanbul ignore next */
+          const firstArgIsString = typeof args[0] === 'string';
           if (
+            firstArgIsString &&
             args[0].indexOf('Warning: Do not await the result of calling TestRenderer.act') === 0
           ) {
             // v16.8.6
             isAsyncActSupported = false;
           } else if (
+            firstArgIsString &&
             args[0].indexOf(
               'Warning: The callback passed to TestRenderer.act(...) function must not return anything',
             ) === 0


### PR DESCRIPTION
prevents asyncAct throwing an error if the item being logged isn't a string.

Coped mostly from https://github.com/testing-library/react-testing-library/pull/476

<!--

Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!

-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
Following a [similar PR made in react-testing-library](https://github.com/testing-library/react-testing-library/pull/476), this fixes an issue where act-compat assumed console.error was being called with a string.

**Why**:

<!-- Why are these changes necessary? -->
Current implementation assumes console.error was always called with a string even though it could be called with other types.

**How**:
Wrapped execution of code in a type check if statement to ensure operations are done only on string types.

<!-- How were these changes implemented? -->

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/bcarroll22/native-testing-library-docs)
- [ ] Typescript definitions updated
- [x] Tests
- [ ] Ready to be merged <!-- In your opinion -->

<!-- feel free to add additional comments -->
