### PR TITLE
Change validTargets to list of components, not component names

### DIFF
--- a/src/__tests__/events.js
+++ b/src/__tests__/events.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactNative from 'react-native';
 import '@testing-library/jest-native/extend-expect';
 import { Button, Image, Text, TextInput, TouchableHighlight } from 'react-native';
 
@@ -6,27 +7,29 @@ import { render, fireEvent, eventMap, getEventHandlerName, wait, cleanup } from 
 
 afterEach(cleanup);
 
-Object.keys(eventMap).forEach(key => {
-  describe(`${key} events`, () => {
-    const config = eventMap[key];
+Object.keys(eventMap).forEach(ComponentName => {
+  describe(`${ComponentName} events`, () => {
+    const config = eventMap[ComponentName];
 
     config.forEach(event => {
-      const spy = jest.fn();
-      const handlerName = getEventHandlerName(event);
+      test(event, () => {
+        const spy = jest.fn();
+        const handlerName = getEventHandlerName(event);
 
-      const {
-        container: {
-          children: [target],
-        },
-      } = render(
-        React.createElement(key, {
-          [handlerName]: spy,
-        }),
-      );
+        const {
+          container: {
+            children: [target],
+          },
+        } = render(
+          React.createElement(ReactNative[ComponentName], {
+            [handlerName]: spy,
+          }),
+        );
 
-      fireEvent[event](target);
+        fireEvent[event](target);
 
-      expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledTimes(1);
+      });
     });
   });
 });

--- a/src/lib/events.js
+++ b/src/lib/events.js
@@ -1,3 +1,5 @@
+import ReactNative from 'react-native';
+
 const viewEvents = [
   'accessibilityEscape',
   'accessibilityTap',
@@ -83,7 +85,9 @@ class NativeTestEvent {
   constructor(typeArg, ...args) {
     this.args = args;
     this.typeArg = typeArg;
-    this.validTargets = Object.keys(eventMap).filter(c => eventMap[c].includes(typeArg));
+    this.validTargets = Object.keys(eventMap)
+      .filter(c => eventMap[c].includes(typeArg))
+      .map(ComponentName => ReactNative[ComponentName]);
   }
 
   set target(target) {


### PR DESCRIPTION
**What**:

Before this change, `NativeTestEvent.validTargets` was an array of component names. Now it is an array of actual React Native components.

In addition, this diff fixes a bug in event tests where a `describe()` instead of a `test()` was being used, so the tests for every supported (component, event) pair were not being run (or were not being reported by the test runner).

**Why**:

I ran into a possible bug, when writing tests within an Expo project and using the "jest-expo" preset. I tried to `fireEvent` on a Switch element, but the handler for the event was never called. Digging in, I realized that my Switch's `element.type` was not the string "Switch"; it was the React Native Switch component class, which made me think that the assumption that `element.type` should be a string in `validTargets` is wrong.

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the 
      [docs site](https://github.com/bcarroll22/native-testing-library-docs) (N/A)
- [x] Typescript definitions updated (none to update as far as I can tell)
- [x] Tests
- [x] Ready to be merged <!-- In your opinion -->

<!-- feel free to add additional comments -->
