### PR TITLE
improvement(Events): Add View touch events

### DIFF
--- a/src/lib/events.js
+++ b/src/lib/events.js
@@ -13,6 +13,10 @@ const viewEvents = [
   'responderTerminationRequest',
   'startShouldSetResponder',
   'startShouldSetResponderCapture',
+  'touchCancel',
+  'touchEnd',
+  'touchMove',
+  'touchStart',
 ];
 
 const eventMap = {

--- a/typings/events.d.ts
+++ b/typings/events.d.ts
@@ -1,6 +1,8 @@
 import { NativeTestInstance } from './query-helpers';
 
 export type EventType =
+  | 'accessibilityEscape'
+  | 'accessibilityTap'
   | 'focus'
   | 'blur'
   | 'change'
@@ -24,7 +26,22 @@ export type EventType =
   | 'load'
   | 'error'
   | 'progress'
-  | 'custom';
+  | 'custom'
+  | 'magicTap'
+  | 'moveShouldSetResponder'
+  | 'moveShouldSetResponderCapture'
+  | 'responderGrant'
+  | 'responderMove'
+  | 'responderReject'
+  | 'responderRelease'
+  | 'responderTerminate'
+  | 'responderTerminationRequest'
+  | 'startShouldSetResponder'
+  | 'startShouldSetResponderCapture'
+  | 'touchCancel'
+  | 'touchEnd'
+  | 'touchMove'
+  | 'touchStart';
 
 export declare class NativeTestEvent {
   constructor(typeArg: string, ...params: any[]);
@@ -32,7 +49,7 @@ export declare class NativeTestEvent {
 
 export type FireFunction = (element: NativeTestInstance, event: NativeTestEvent) => boolean;
 export type FireObject = {
-  [K in EventType]: (element: NativeTestInstance, options?: {}) => boolean
+  [K in EventType]: (element: NativeTestInstance, options?: {}) => boolean;
 };
 
 export const getEventHandlerName: (key: string) => string;


### PR DESCRIPTION
**What**:

Add the `View` **touch** events to the list of events that can be fired. I also added some other `View` events that were not in the types list to the TS definitions file.

**Why**:

In order to be able to test that something happens when these touch events are fired I need them to be inside the list of events.

**Checklist**:

- [ ] Documentation added to the
      [docs site](https://github.com/bcarroll22/native-testing-library-docs)(N/A)
- [x] Typescript definitions updated
- [ ] Tests(N/A)
- [x] Ready to be merged
