### PR TITLE
Remove obsoleted native component mocking

### DIFF
--- a/src/preset/mock-modules.js
+++ b/src/preset/mock-modules.js
@@ -31,15 +31,4 @@ jest.doMock('react-native/Libraries/Components/Picker/Picker', () => {
 });
 
 // Re-mock ReactNative with native methods mocked
-jest
-  .mock('react-native/Libraries/Animated/src/NativeAnimatedHelper')
-  .doMock('react-native/Libraries/Renderer/shims/ReactNative', () => {
-    const ReactNative = jest.requireActual('react-native/Libraries/Renderer/shims/ReactNative');
-    const NativeMethodsMixin =
-      ReactNative.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.NativeMethodsMixin;
-
-    Object.assign(NativeMethodsMixin, mockNativeMethods);
-    Object.assign(ReactNative.NativeComponent.prototype, mockNativeMethods);
-
-    return ReactNative;
-  });
+jest.mock('react-native/Libraries/Animated/src/NativeAnimatedHelper');


### PR DESCRIPTION
<!--

Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!

-->

**What**: Remove deprecated native component mocking process. The internal codes in React Native are changed since 0.63. This is suggested in #126 by *TheSavior*

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**Why**: The mocking about the native component has to be refactored. This is the first step to that.

<!-- Why are these changes necessary? -->

**How**:

<!-- How were these changes implemented? -->

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/bcarroll22/native-testing-library-docs)
- [ ] Typescript definitions updated
- [ ] Tests
- [x] Ready to be merged <!-- In your opinion -->

<!-- feel free to add additional comments -->
